### PR TITLE
Fix Bag Speed missing Cloaker explosives value: Closes #10

### DIFF
--- a/Bag Speed - Gab/code.lua
+++ b/Bag Speed - Gab/code.lua
@@ -52,4 +52,8 @@ function CarryTweakData:init(tweak_data)
 		can_run = true,
 		throw_distance_multiplier = 1
 	}
+		self.types.explosives = deep_clone(self.types.medium)
+	self.types.explosives.can_explode = true
+	self.types.cloaker_explosives = deep_clone(self.types.medium)
+	self.types.cloaker_explosives.can_poof = true
 end


### PR DESCRIPTION
Without these values set the game crashes on Cursed Kill Room